### PR TITLE
Base para criação de relatório consolidado

### DIFF
--- a/docs/drop.sql
+++ b/docs/drop.sql
@@ -1,0 +1,7 @@
+drop table activities cascade;
+drop table executions cascade;
+drop table health_institution_roles cascade;
+drop table health_institutions cascade;
+drop table role_activities cascade;
+drop table roles cascade;
+drop table technologies cascade;

--- a/docs/test-data.sql
+++ b/docs/test-data.sql
@@ -1,0 +1,343 @@
+
+-- ****************************************
+-- health_institutions
+-- ****************************************
+
+INSERT INTO public.health_institutions(id, name, time_tracking_code, administration_code) VALUES (1, 'Hospital São Lucas', 'HSLC', 'HSLG');
+INSERT INTO public.health_institutions(id, name, time_tracking_code, administration_code) VALUES (2, 'Hospital de Clinicas de Porto Alegre', 'HCPC', 'HCPG');
+INSERT INTO public.health_institutions(id, name, time_tracking_code, administration_code) VALUES (3, 'Grupo Hospitalar Conceição', 'GHCC', 'GHCG');
+INSERT INTO public.health_institutions(id, name, time_tracking_code, administration_code) VALUES (4, 'Hospital de Pronto Socorro', 'HSPC', 'HPSG');
+INSERT INTO public.health_institutions(id, name, time_tracking_code, administration_code) VALUES (5, 'Hospital Moinhos de Vento', 'HMVC', 'HMVG');
+
+SELECT setval('health_institutions_id_seq', 5, true);
+
+-- ****************************************
+-- technologies
+-- ****************************************
+
+INSERT INTO public.technologies(id, name, health_institution_id) VALUES (1, 'AVC', 5);
+INSERT INTO public.technologies(id, name, health_institution_id) VALUES (2, 'Prótese', 1);
+
+SELECT setval('technologies_id_seq', 2, true);
+
+-- ****************************************
+-- activities
+-- ****************************************
+
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (1, 'Administração de antihipertensivo EV', 'Adm. antihipertensivo', 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (2, 'Administração de medicamentos', 'Adm. meds.', 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (3, 'Administração de trombolítico', 'Adm. tromb.', 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (4, 'Administração de medicamentos para sedação', 'Adm. meds. sedação', 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (5, 'Agendamento / adminsitração', 'Ag./adm.', 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (6, 'Análise de criterios de exclusão', 'Análise crit. excl.', 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (7, 'Aquisição das imagens na radiologia ou hemodinâmica', 'Aquis. imagens rad./hem.', 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (8, 'Auxílio na trombectomia mecânica', 'Aux. tromb. mec.', 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (9, 'Auxílio para alimentação', 'Aux. alim.', 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (10, 'Banho leito / higienização do paciente ', 'Banho/Higienização', 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (11, 'Cirurgia', null, 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (12, 'Coleta de exames laboratoriais (sangue, etc)', 'Coleta ex. lab.', 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (13, 'Confirma hipótese AVC', 'Conf. hip. AVC', 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (14, 'Consulta', null, 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (15, 'Cuidados na SR', null, 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (16, 'Exames de imagem', 'Ex. imagem', 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (17, 'Exames laboratoriais', 'Ex. lab.', 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (18, 'Gasometria', null, 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (19, 'Higiene oral', 'Hig. oral', 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (20, 'Laudo do exame', null, 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (21, 'Monitorização', null, 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (22, 'Passagem de sonda', 'Pass. sonda', 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (23, 'Transporte', null, 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (24, 'Transporte até a Ressonância', 'Transp. Ress.', 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (25, 'Triagem', null, 1);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (26, 'Trombectomia mecânica', 'Tromb. mec.', 1);
+
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (27, 'Avaliação recepção do Paciente', 'Aval. recepção pac.', 2);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (28, 'Preparo para cirurgia', 'Prep. cirurgia', 2);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (29, 'Radiografias', null, 2);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (30, 'Cirurgia', null, 2);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (31, 'Limpeza  e esterilização', 'Limp. esterilização', 2);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (32, 'Cuidados na SR', 'Cuidados SR', 2);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (33, 'Consultas de rotina na internação', 'Cons. rotina intern.', 2);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (34, 'Cuidados com paciente na internação', 'Cuidados pac. intern.', 2);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (35, 'Transporte', null, 2);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (36, 'Análise de exames', 'Análise ex.', 2);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (37, 'Procedimentos do pós operatório', 'Proc. pós-op.', 2);
+INSERT INTO public.activities(id, name, short_name, technology_id) VALUES (38, 'Adm de medicamentos', 'Adm. meds.', 2);
+
+SELECT setval('activities_id_seq', 38, true);
+
+-- ****************************************
+-- roles
+-- ****************************************
+
+INSERT INTO public.roles(id, name, short_name) VALUES (1, 'Médico Emergencista', 'Emergencista');
+INSERT INTO public.roles(id, name, short_name) VALUES (2, 'Adminstrativo', 'Adm.');
+INSERT INTO public.roles(id, name, short_name) VALUES (3, 'Técnico Radiologista', 'Téc. Radio');
+INSERT INTO public.roles(id, name, short_name) VALUES (4, 'Médico intensivista', 'Intensivista');
+INSERT INTO public.roles(id, name, short_name) VALUES (5, 'Residente Enfermagem', 'Res. Enferm.');
+INSERT INTO public.roles(id, name, short_name) VALUES (6, 'Nutricionista', 'Nutri');
+INSERT INTO public.roles(id, name, short_name) VALUES (7, 'Residente Fisioterapia', 'Res. Fisio');
+INSERT INTO public.roles(id, name, short_name) VALUES (8, 'Fonoaudiologo', 'Fono');
+INSERT INTO public.roles(id, name, short_name) VALUES (9, 'Farmaceutico', null);
+INSERT INTO public.roles(id, name, short_name) VALUES (10, 'Psicólogo', null);
+INSERT INTO public.roles(id, name, short_name) VALUES (11, 'Fisioterapeuta', 'Fisio');
+INSERT INTO public.roles(id, name, short_name) VALUES (12, 'Assistente Social', null);
+INSERT INTO public.roles(id, name, short_name) VALUES (13, 'Médico cirurgião', 'Cirurgião');
+INSERT INTO public.roles(id, name, short_name) VALUES (14, 'Odontologista', 'Odonto');
+INSERT INTO public.roles(id, name, short_name) VALUES (15, 'Médico Vascular', null);
+INSERT INTO public.roles(id, name, short_name) VALUES (16, 'Médico Clínico', null);
+INSERT INTO public.roles(id, name, short_name) VALUES (17, 'Médico emergencista', 'emergencista');
+INSERT INTO public.roles(id, name, short_name) VALUES (18, 'Médico cardiologista', 'cardiologista');
+INSERT INTO public.roles(id, name, short_name) VALUES (19, 'Médico anestesiologista', 'anestesiologista');
+INSERT INTO public.roles(id, name, short_name) VALUES (20, 'Técnico Enfermagem', 'Téc. Enferm.');
+INSERT INTO public.roles(id, name, short_name) VALUES (21, 'Médico Neurologista', 'Neuro');
+INSERT INTO public.roles(id, name, short_name) VALUES (22, 'Médico Radiologista', 'Radiolog.');
+INSERT INTO public.roles(id, name, short_name) VALUES (23, 'Médico Neurointervencionista (pode ser neurologista ou neurocirurgião)', 'Neurointervenc.');
+INSERT INTO public.roles(id, name, short_name) VALUES (24, 'Médico Residente', 'Residente');
+INSERT INTO public.roles(id, name, short_name) VALUES (25, 'Enfermeiro', null);
+
+INSERT INTO public.roles(id, name, short_name) VALUES (26, 'Anestesista', null);
+INSERT INTO public.roles(id, name, short_name) VALUES (27, 'enfermeiro', null);
+INSERT INTO public.roles(id, name, short_name) VALUES (28, 'cirurgião', null);
+INSERT INTO public.roles(id, name, short_name) VALUES (29, 'Assistente do cirurgião 1 ', 'Assist. 1');
+INSERT INTO public.roles(id, name, short_name) VALUES (30, 'Assistente do cirurgião 2 ', 'Assist. 2');
+INSERT INTO public.roles(id, name, short_name) VALUES (31, 'Radiologista', null);
+INSERT INTO public.roles(id, name, short_name) VALUES (32, 'Tecnico de enfermagem', 'Tec. enferm.');
+INSERT INTO public.roles(id, name, short_name) VALUES (33, 'Profissional de limpeza', null);
+INSERT INTO public.roles(id, name, short_name) VALUES (34, 'Cardiologista', 'Cardio');
+INSERT INTO public.roles(id, name, short_name) VALUES (35, 'Psiquiatra', null);
+INSERT INTO public.roles(id, name, short_name) VALUES (36, 'Gastroenterologista', 'Gastro');
+INSERT INTO public.roles(id, name, short_name) VALUES (37, 'Fisiatra', null);
+INSERT INTO public.roles(id, name, short_name) VALUES (38, 'Neurologista', 'Neuro');
+INSERT INTO public.roles(id, name, short_name) VALUES (39, 'Medicina Interna', 'Med. Interna');
+INSERT INTO public.roles(id, name, short_name) VALUES (40, 'Outros profissionais médicos', null);
+
+SELECT setval('roles_id_seq', 40, true);
+
+-- ****************************************
+-- health_institution_roles
+-- ****************************************
+
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 1);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 2);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 3);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 4);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 5);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 6);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 7);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 8);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 9);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 10);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 11);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 12);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 13);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 14);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 15);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 16);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 17);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 18);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 19);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 20);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 21);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 22);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 23);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 24);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (5, 25);
+
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (1, 26);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (1, 27);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (1, 28);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (1, 29);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (1, 30);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (1, 31);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (1, 32);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (1, 33);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (1, 34);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (1, 35);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (1, 36);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (1, 37);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (1, 38);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (1, 39);
+INSERT INTO public.health_institution_roles(health_institution_id, role_id) VALUES (1, 40);
+
+-- ****************************************
+-- role_activities
+-- ****************************************
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (25, 1);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (21, 1);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (24, 1);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (16, 1);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (1, 1);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (25, 2);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (20, 2);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (21, 2);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (24, 2);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (25, 3);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (20, 3);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (9, 3);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (21, 3);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (24, 3);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (17, 3);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (19, 4);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (21, 5);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (20, 5);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (24, 5);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (25, 5);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (2, 5);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (21, 6);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (24, 6);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (22, 7);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (20, 8);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (25, 9);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (25, 10);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (13, 11);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (20, 12);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (21, 13);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (24, 13);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (16, 13);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (17, 13);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (19, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (4, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (5, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (6, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (7, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (25, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (8, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (20, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (9, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (10, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (11, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (12, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (13, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (14, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (15, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (21, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (24, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (16, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (17, 14);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (18, 14);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (19, 15);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (21, 16);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (24, 16);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (22, 16);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (22, 17);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (25, 18);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (25, 19);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (22, 20);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (21, 21);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (24, 21);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (25, 21);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (20, 21);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (25, 22);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (25, 23);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (20, 23);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (21, 24);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (24, 24);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (21, 25);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (24, 25);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (25, 25);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (22, 26);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (23, 26);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (24, 26);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (25, 26);
+
+--
+--
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (27, 27);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (11, 27);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (6, 27);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (27, 28);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (32, 28);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (27, 29);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (31, 29);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (32, 29);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (26, 30);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (27, 30);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (28, 30);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (29, 30);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (30, 30);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (32, 30);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (27, 31);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (29, 31);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (32, 31);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (33, 31);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (26, 32);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (27, 32);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (28, 32);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (29, 32);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (30, 32);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (11, 32);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (6, 32);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (26, 33);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (27, 33);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (28, 33);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (29, 33);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (30, 33);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (11, 33);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (6, 33);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (33, 33);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (34, 33);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (35, 33);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (36, 33);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (37, 33);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (38, 33);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (39, 33);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (40, 33);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (32, 34);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (29, 35);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (32, 35);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (26, 36);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (28, 36);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (29, 36);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (30, 36);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (34, 36);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (35, 36);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (36, 36);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (37, 36);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (38, 36);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (39, 36);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (40, 36);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (27, 37);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (28, 37);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (29, 37);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (30, 37);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (32, 37);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (34, 37);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (35, 37);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (36, 37);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (37, 37);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (38, 37);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (39, 37);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (40, 37);
+
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (27, 38);
+INSERT INTO public.role_activities(role_id, activity_id) VALUES (32, 38);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2990,6 +2990,14 @@
         "capture-stack-trace": "^1.0.0"
       }
     },
+    "cron": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-1.8.2.tgz",
+      "integrity": "sha512-Gk2c4y6xKEO8FSAUTklqtfSr7oTq0CiPQeLBG5Fl0qoXpZyMcj1SG59YL+hqq04bu6/IuEA7lMkYDAplQNKkyg==",
+      "requires": {
+        "moment-timezone": "^0.5.x"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "docs": "node docs/update.js ./docs/"
   },
   "dependencies": {
+    "cron": "^1.8.2",
     "dotenv": "^8.2.0",
     "exceljs": "^3.9.0",
     "express": "~4.16.1",

--- a/src/config.js
+++ b/src/config.js
@@ -1,9 +1,9 @@
 export default {
   port: parseInt(process.env.PORT, 10),
-
   databaseURL: process.env.DB_URL,
 
-  jwtSecret: process.env.JWT_SECRET,
-  jwtExpiresIn: process.env.JWT_EXPIRES_IN,
-  adminCode: process.env.ADMIN_CODE,
+  jwtSecret: process.env.JWT_SECRET ?? "secret-key",
+  jwtExpiresIn: process.env.JWT_EXPIRES_IN ?? "1h",
+  reportsCronFrequency: process.env.REPORTS_CRON_FREQUENCY ?? "*/15 * * * *",
+  adminCode: process.env.ADMIN_CODE ?? "0000",
 }

--- a/src/jobs/index.js
+++ b/src/jobs/index.js
@@ -1,0 +1,3 @@
+/* eslint-disable import/prefer-default-export */
+
+export { default as simpleExecutionReport } from "./simpleExecutionReport"

--- a/src/jobs/simpleExecutionReport.js
+++ b/src/jobs/simpleExecutionReport.js
@@ -1,0 +1,20 @@
+import { CronJob } from "cron"
+import { Container } from "typedi"
+import config from "../config"
+import { ExecutionService } from "../services"
+
+/**
+ * Job para atualizar o relatório consolidados das execuções.
+ * 
+ * Configurado por `config.reportsCronFrequency`, atualiza toda a tabela de
+ * atividades x ocupações com as novas durações mínima, mediana e máxima para
+ * cada entrada na tabela.
+ */
+export default () => {
+  new CronJob(config.reportsCronFrequency, () => {
+    (async () => {
+      const executionService = Container.get(ExecutionService)
+      await executionService.updateConsolidatedReport()
+    })()
+  }).start()
+}

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -2,6 +2,7 @@ import configLoader from "./config"
 import loggerLoader from "./logger"
 import expressLoader from "./express"
 import sequelizeLoader from "./sequelize"
+import jobsLoader from "./jobs"
 
 /* eslint-disable no-console */
 
@@ -21,4 +22,8 @@ export default async app => {
   // database
   await sequelizeLoader()
   console.info("✅ Sequelize loaded")
+
+  // jobs
+  await jobsLoader()
+  console.info("✅ Jobs loaded and started")
 }

--- a/src/loaders/jobs.js
+++ b/src/loaders/jobs.js
@@ -1,0 +1,5 @@
+import { simpleExecutionReport } from "../jobs"
+
+export default () => {
+  simpleExecutionReport()
+}

--- a/src/models/ActivityDAO.js
+++ b/src/models/ActivityDAO.js
@@ -14,7 +14,7 @@ export const setup = sequelize => {
         type: DataTypes.STRING,
         allowNull: false,
       },
-      short_name: DataTypes.STRING,
+      shortName: DataTypes.STRING,
     },
     { sequelize, modelName: "activity" }
   )

--- a/src/models/RoleActivityDAO.js
+++ b/src/models/RoleActivityDAO.js
@@ -1,7 +1,11 @@
-import { Model } from "sequelize"
+import { Model, DataTypes } from "sequelize"
 
 export default class RoleActivityDAO extends Model {}
 
 export const setup = sequelize => {
-  RoleActivityDAO.init({}, { sequelize, modelName: "role_activity" })
+  RoleActivityDAO.init({
+    minimum: DataTypes.DOUBLE,
+    median: DataTypes.DOUBLE,
+    maximum: DataTypes.DOUBLE,
+  }, { sequelize, modelName: "role_activity" })
 }

--- a/src/models/RoleActivityDAO.js
+++ b/src/models/RoleActivityDAO.js
@@ -7,5 +7,6 @@ export const setup = sequelize => {
     minimum: DataTypes.DOUBLE,
     median: DataTypes.DOUBLE,
     maximum: DataTypes.DOUBLE,
+    lastUpdate: DataTypes.DATE,
   }, { sequelize, modelName: "role_activity" })
 }

--- a/src/models/RoleDAO.js
+++ b/src/models/RoleDAO.js
@@ -14,6 +14,7 @@ export const setup = sequelize => {
         type: DataTypes.STRING,
         allowNull: false,
       },
+      shortName: DataTypes.STRING,
     },
     { sequelize, modelName: "role" }
   )

--- a/src/services/ActivityService.js
+++ b/src/services/ActivityService.js
@@ -4,7 +4,7 @@ export default class ActivityService {
   /**
    * @param {string} technologyID Código (PK) da tecnologia.
    *
-   * @returns {{ id: integer, name: string, short_name: string }[]} Todas as atividades da atividade
+   * @returns {{ id: integer, name: string, shortName: string }[]} Todas as atividades da atividade
    */
   async listActivities(technologyID) {
     const technology = await TechnologyDAO.findByPk(technologyID, {
@@ -15,7 +15,7 @@ export default class ActivityService {
       return {
         id: activity.id,
         name: activity.name,
-        short_name: activity.short_name,
+        shortName: activity.shortName,
       }
     })
   }

--- a/src/services/ExecutionService.js
+++ b/src/services/ExecutionService.js
@@ -17,10 +17,10 @@ export default class ExecutionService {
   }
 
   /**
-   * Atualiza os relatórios consolidados na tabela `roles_activities`.
-   * 
+   * Atualiza os relatórios consolidados na tabela `role_activities`.
+   *
    * Essa função atualiza as durações mínima, mediana e máxima de todos os pares
-   * atividade x ocupação.
+   * atividade x ocupação, assim como o timestamp da última consolidação.
    */
   async updateConsolidatedReport() {
     // TODO: implementar (https://trello.com/c/HiBdKv5z)
@@ -28,10 +28,10 @@ export default class ExecutionService {
 
   /**
    * Gera um relatório com os dados consolidados das execuções de atividades de uma tecnologia.
-   * 
+   *
    * Atividades que não tiveram execuções por uma ocupação retornarão com durações iguais a `0`. Por exemplo,
    * se nenhum anestesista executou a atividade "Cuidados na SR", será retornado um objeto conforme xemplo abaixo:
-   * 
+   *
    * ```
    *     {
    *       activityID: 3,
@@ -43,20 +43,12 @@ export default class ExecutionService {
    *       maximumDuration: 0,
    *     }
    * ```
-   * 
+   *
    * @param {number} technologyID ID da tecnologia cujo relatório consolidado deve ser exportado.
-   * @returns {Promise<ConsolidatedReport[]>} Objeto com informações consolidadas sobre todas as execuções de atividades da tecnologia.
-   * 
+   * @returns {Promise<ConsolidatedReportEntry[]>} Objeto com informações consolidadas sobre todas as execuções de atividades da tecnologia.
+   *
    * ----
-   * 
-   * @typedef {Object} ConsolidatedReport Objeto com dados consolidados de múltiplas execuções.
-   * @property {CondolidatedReportSummary} summary "Resumo" das execuções.
-   * @property {ConsolidatedReportEntry[]} activities Lista com os dados consolidados de cada par atividade-ocupação, ordenados pelo nome da ocupação.
-   * 
-   * @typedef {Object} CondolidatedReportSummary Objeto que descreve o resumo do relatório consolidado.
-   * @property {number} activitiesExecuted Quantas vezes as atividades da tecnologia foram executadas.
-   * @property {number} timeSpent Minutos totais gastos na execução de atividades da tecnologia.
-   * 
+   *
    * @typedef {Object} ConsolidatedReportEntry Objeto que descreve um registro consolidado de execuções de um par atividade-ocupação.
    * @property {number} activityID ID da atividade.
    * @property {string} activity Nome da atividade.
@@ -65,28 +57,24 @@ export default class ExecutionService {
    * @property {number} minimumDuration Duração mínima das execuções, em minutos.
    * @property {number} medianDuration Mediana das durações das execuções, em minutos.
    * @property {number} maximumDuration Duração máxima das execuções, em minutos.
+   * @property {string} lastUpdate Data/hora da última atualização dos dados consolidados (ISO 8601).
    */
-  async exportConsolidatedReport(technologyID) {
+  async exportConsolidatedExecutions(technologyID) {
     // TODO: implementar (https://trello.com/c/HiBdKv5z)
 
     // exemplo de retorno
-    return {
-      summary: {
-        activitiesExecuted: 2,
-        timestamp: 300 // minutos
+    return [
+      {
+        activityID: 1,
+        activity: "Cirurgia",
+        roleID: 2,
+        role: "Anestesista",
+        minimumDuration: 37 / 60, // armazenado no banco em segundos, deve retornar em minutos
+        medianDuration: 72 / 60, // armazenado no banco em segundos, deve retornar em minutos
+        maximumDuration: 129 / 60, // armazenado no banco em segundos, deve retornar em minutos
+        lastUpdate: "2020-06-03T12:40:32-0300", // ISO 8601
       },
-      activities: [
-        {
-          activityID: 1,
-          activity: "Cirurgia",
-          roleID: 2,
-          role: "Anestesista",
-          minimumDuration: 37 / 60, // armazenado no banco em segundos, deve retornar em minutos
-          medianDuration: 72 / 60, // armazenado no banco em segundos, deve retornar em minutos
-          maximumDuration: 129 / 60 // armazenado no banco em segundos, deve retornar em minutos
-        }
-      ]
-    }
+    ]
   }
 
   /**
@@ -96,7 +84,7 @@ export default class ExecutionService {
    * @returns {Promise<ExecutionEntry[]>} Lista com todas as execuções da tecnologia, ordenada pelo nome da ocupação.
    *
    * ----
-   * 
+   *
    * Objeto que descreve um registro de execução.
    * @typedef {Object} ExecutionEntry
    * @property {string} activity Nome da atividade.

--- a/src/services/ExecutionService.js
+++ b/src/services/ExecutionService.js
@@ -17,6 +17,16 @@ export default class ExecutionService {
   }
 
   /**
+   * Atualiza os relatórios consolidados na tabela `roles_activities`.
+   * 
+   * Essa função atualiza as durações mínima, mediana e máxima de todos os pares
+   * atividade x ocupação.
+   */
+  async updateConsolidatedReport() {
+    // TODO: implementar (https://trello.com/c/HiBdKv5z)
+  }
+
+  /**
    * Gera um relatório com os dados consolidados das execuções de atividades de uma tecnologia.
    * 
    * Atividades que não tiveram execuções por uma ocupação retornarão com durações iguais a `0`. Por exemplo,
@@ -35,7 +45,7 @@ export default class ExecutionService {
    * ```
    * 
    * @param {number} technologyID ID da tecnologia cujo relatório consolidado deve ser exportado.
-   * @returns {ConsolidatedReportEntry[]} Lista com os dados consolidados de cada par atividade-ocupação, ordenados pelo nome da ocupação.
+   * @returns {Promise<ConsolidatedReportEntry[]>} Lista com os dados consolidados de cada par atividade-ocupação, ordenados pelo nome da ocupação.
    * 
    * ----
    * 
@@ -70,7 +80,7 @@ export default class ExecutionService {
    * Gera um relatório com todas as execuções de atividades de uma tecnologia.
    *
    * @param {number} technologyID ID da tecnologia cujas execuções devem ser exportadas.
-   * @returns {ExecutionEntry[]} Lista com todas as execuções da tecnologia, ordenada pelo nome da ocupação.
+   * @returns {Promise<ExecutionEntry[]>} Lista com todas as execuções da tecnologia, ordenada pelo nome da ocupação.
    *
    * ----
    * 

--- a/src/services/ExecutionService.js
+++ b/src/services/ExecutionService.js
@@ -45,12 +45,19 @@ export default class ExecutionService {
    * ```
    * 
    * @param {number} technologyID ID da tecnologia cujo relatório consolidado deve ser exportado.
-   * @returns {Promise<ConsolidatedReportEntry[]>} Lista com os dados consolidados de cada par atividade-ocupação, ordenados pelo nome da ocupação.
+   * @returns {Promise<ConsolidatedReport[]>} Objeto com informações consolidadas sobre todas as execuções de atividades da tecnologia.
    * 
    * ----
    * 
-   * Objeto que descreve um registro consolidado de execuções de um par atividade-ocupação.
-   * @typedef {Object} ConsolidatedReportEntry
+   * @typedef {Object} ConsolidatedReport Objeto com dados consolidados de múltiplas execuções.
+   * @property {CondolidatedReportSummary} summary "Resumo" das execuções.
+   * @property {ConsolidatedReportEntry[]} activities Lista com os dados consolidados de cada par atividade-ocupação, ordenados pelo nome da ocupação.
+   * 
+   * @typedef {Object} CondolidatedReportSummary Objeto que descreve o resumo do relatório consolidado.
+   * @property {number} activitiesExecuted Quantas vezes as atividades da tecnologia foram executadas.
+   * @property {number} timeSpent Minutos totais gastos na execução de atividades da tecnologia.
+   * 
+   * @typedef {Object} ConsolidatedReportEntry Objeto que descreve um registro consolidado de execuções de um par atividade-ocupação.
    * @property {number} activityID ID da atividade.
    * @property {string} activity Nome da atividade.
    * @property {number} roleID ID da ocupação.
@@ -59,21 +66,27 @@ export default class ExecutionService {
    * @property {number} medianDuration Mediana das durações das execuções, em minutos.
    * @property {number} maximumDuration Duração máxima das execuções, em minutos.
    */
-  async exportConsolidatedExecutions(technologyID) {
+  async exportConsolidatedReport(technologyID) {
     // TODO: implementar (https://trello.com/c/HiBdKv5z)
 
     // exemplo de retorno
-    return [
-      {
-        activityID: 1,
-        activity: "Cirurgia",
-        roleID: 2,
-        role: "Anestesista",
-        minimumDuration: 37 / 60, // armazenado no banco em segundos, deve retornar em minutos
-        medianDuration: 72 / 60, // armazenado no banco em segundos, deve retornar em minutos
-        maximumDuration: 129 / 60 // armazenado no banco em segundos, deve retornar em minutos
-      }
-    ]
+    return {
+      summary: {
+        activitiesExecuted: 2,
+        timestamp: 300 // minutos
+      },
+      activities: [
+        {
+          activityID: 1,
+          activity: "Cirurgia",
+          roleID: 2,
+          role: "Anestesista",
+          minimumDuration: 37 / 60, // armazenado no banco em segundos, deve retornar em minutos
+          medianDuration: 72 / 60, // armazenado no banco em segundos, deve retornar em minutos
+          maximumDuration: 129 / 60 // armazenado no banco em segundos, deve retornar em minutos
+        }
+      ]
+    }
   }
 
   /**

--- a/src/services/ReportService.js
+++ b/src/services/ReportService.js
@@ -5,7 +5,7 @@ export default class ReportService {
    * Gera um relatório completo com todos os dados de uma instituição de saúde.
    *
    * @param {number} institutionID ID da instituição cujo relatório deve ser gerado.
-   * @returns {string} Nome do arquivo XLSX temporário.
+   * @returns {Promise<string>} Nome do arquivo XLSX temporário.
    */
   async generateCompleteReport(institutionID) {
     // TODO: implementar na task B03 (https://trello.com/c/VXgx1w4r)

--- a/src/services/RoleService.js
+++ b/src/services/RoleService.js
@@ -15,6 +15,7 @@ export default class RoleService {
       return {
         id: role.id,
         name: role.name,
+        shortName: role.shortName
       }
     })
 
@@ -27,7 +28,7 @@ export default class RoleService {
         return {
           id: activity.id,
           name: activity.name,
-          shortName: activity.short_name,
+          shortName: activity.shortName,
         }
       })
     }

--- a/src/services/TechnologyService.js
+++ b/src/services/TechnologyService.js
@@ -25,7 +25,7 @@ export default class TechnologyService {
         return {
           id: activity.id,
           name: activity.name,
-          shortName: activity.short_name,
+          shortName: activity.shortName,
         }
       })
     }


### PR DESCRIPTION
Mudanças:
- atualiza o contrato da função `ExecutionService.exportConsolidatedExecutions` para incluir a data da última atualização dos dados consolidados;
- cria a base para a execução de tasks repetitivas usando [cron jobs](https://en.wikipedia.org/wiki/Cron) (ver abaixo racional sobre lib escolhida);
- atualiza os DAOs para suportar (a) gerar relatórios consolidados com durações mínima, mediana e máxima de cada par atividade x ocupação (com data da última atualização desses campos consolidados), e (b) nome curto de uma ocupação;
- atualiza alguns lugares onde estava sendo usado `snake_case` para `lowerCamelCase`;
- adiciona um script SQL para remover todas as tabelas do banco (necessário quando há mudanças no DAO, porque o Sequelize não faz um diff e update apenas das mudanças), e um script para inserção de dados de teste (hospitais, tecnologias, atividades e ocupações).

**Autor:** Rafael Araujo

## Checklist

- 🤷‍♀️ funciona conforme especificação no Postman
- ❌ possui testes de unidade/integração associados
- 🤷‍♀️ mantém cobertura de pelo menos 50%
- ✅ documentação atualizada
- ✅ código dentro dos padrões
- ⚠️ código sem warnings ou erros de linter **==> warnings serão corrigidos quando métodos especificados forem implementados**
- ✅ adiciona dependências externas (✅ aprovadas pelos AGES III)

## Outras informações

Sobre a escolha da lib para tasks repetitivas: todas as opções analisadas são equivalentes em funcionalidade, o critério de escolha foi suporte da comunidade:
- [node-cron](https://www.npmjs.com/package/node-cron): último update há dois anos, 84k downloads semanais;
- [node-schedule](https://www.npmjs.com/package/node-schedule): último update há um ano, 223k downloads semanais;
- [cron](https://www.npmjs.com/package/cron) **(selecionada)**: último update há 4 meses, 614k downloads semanais.